### PR TITLE
Remove duplicate commands

### DIFF
--- a/src/EPS.cpp
+++ b/src/EPS.cpp
@@ -3,38 +3,6 @@
 //
 #include "EPS.h"
 
-EPS::standard_reply EPS::reset_watchdog(DWire &wire, uint8_t i2c_address) {
-    standard_reply reply;
-
-
-    /* Write command to EPS */
-    wire.beginTransmission(i2c_address);
-    wire.write(0x00);
-    wire.write(0x06);
-    wire.write(0x06);
-    wire.write(0x00);
-
-    // delay
-    delay_ms(25);
-
-    // request 5 bytes of data (i.e) the length of the response
-    uint8_t response = wire.requestFrom(i2c_address, 5);
-
-    // if response if 5 bytes long populate reply struct else mark error
-    if (response == 5) {
-        reply.stid = wire.read();
-        reply.ivid = wire.read();
-        reply.rc = wire.read();
-        reply.bid = wire.read();
-        reply.stat = wire.read();
-        reply.error = false;
-    } else {
-        reply.error = true;
-    }
-
-    return reply;
-
-}
 
 EPS::standard_reply EPS::no_operation(DWire &wire, uint8_t i2c_address) {
     standard_reply reply;

--- a/src/EPS.h
+++ b/src/EPS.h
@@ -46,7 +46,6 @@ public:
         uint8_t error;
     };
 
-    static standard_reply reset_watchdog(DWire &wire, uint8_t i2c_address);
     static standard_reply no_operation(DWire &wire, uint8_t i2c_address);
     static standard_reply system_reset(DWire &wire, uint8_t i2c_address);
     static standard_reply cancel_operation(DWire &wire, uint8_t i2c_address);


### PR DESCRIPTION
Remove the duplicate code for the "watchdog" command (ICD page 39).

Issue: https://github.com/davincisatellite/msp-flightsoftware/issues/5